### PR TITLE
fix merkle proof

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,10 +5,10 @@ environment:
   matrix:
     - RUST_INSTALL_TRIPLE: i686-pc-windows-msvc
       VCVARS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\vcvars32.bat"
-      RUST_VERSION: 1.31.0
+      RUST_VERSION: 1.38.0
     - RUST_INSTALL_TRIPLE: x86_64-pc-windows-msvc
       VCVARS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\amd64\\vcvars64.bat"
-      RUST_VERSION: 1.31.0
+      RUST_VERSION: 1.38.0
 
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-${env:RUST_VERSION}-${env:RUST_INSTALL_TRIPLE}.exe"


### PR DESCRIPTION
This PR fix 3 issues:

* fix merkle proof when there is only one element in the tree.
* allow constructing a merkle proof from external. (without the whole tree)
* eliminate `usize` from the interface.

See additional test cases:

https://github.com/nervosnetwork/merkle-tree/compare/master...jjyr:fix-merkle-proof?expand=1#diff-0f411cfbc4f25999296ca7f67965a108R376