### PR TITLE
Use the same Rust version in appveyor as in travis

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,10 +5,10 @@ environment:
   matrix:
     - RUST_INSTALL_TRIPLE: i686-pc-windows-msvc
       VCVARS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\vcvars32.bat"
-      RUST_VERSION: 1.38.0
+      RUST_VERSION: 1.40.0
     - RUST_INSTALL_TRIPLE: x86_64-pc-windows-msvc
       VCVARS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\amd64\\vcvars64.bat"
-      RUST_VERSION: 1.38.0
+      RUST_VERSION: 1.40.0
 
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-${env:RUST_VERSION}-${env:RUST_INSTALL_TRIPLE}.exe"


### PR DESCRIPTION
The Windows CI fails because of the Rust version, so upgrade it to the same version as in Travis.